### PR TITLE
Fix swagger.json according to specification

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -367,18 +367,13 @@
                         "type": "string"
                     },
                     {
-                        "name": "server_id",
-                        "in": "path",
-                        "description": "Server unique identifier",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
                         "name": "action",
                         "in": "body",
                         "description": "Action to execute",
                         "required": true,
-                        "type": "string"
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
[swagger-codegen](https://github.com/swagger-api/swagger-codegen) currently fails to generate client/server from given swagger.json. This small fixes apparently solves the issue (tested with commit 895f13cc118ed1c146ed44ed1ef8a760ad84aa7c).

Moreover the `server_id` parameter was duplicated.