### PR TITLE
Update patch body

### DIFF
--- a/contents/ip.md
+++ b/contents/ip.md
@@ -120,7 +120,6 @@ The response is an object that has a key called `ip`. This key contains a standa
     + Body
 
             {
-                "id": "b50cd740-892d-47d3-8cbf-88510ef626e7",
                 "server": "4a1be97f-e4b1-47fc-b9e6-fc37d17a5198",
                 "reverse": "another-valid.url.com"
             }


### PR DESCRIPTION
The documentation is no more accurate on the `patch` endpoint for IP addresses. The `id` field is no more required and makes request return 400 error like below: 

<pre>
{
   "fields":{
      "id":[
         "extra keys not allowed"
      ]
   },
   "message":"Validation Error",
   "type":"invalid_request_error"
}
</pre>