### PR TITLE
change of format for "extra_volumes"

### DIFF
--- a/contents/image.md
+++ b/contents/image.md
@@ -34,7 +34,7 @@ The response is an object that has a key called `image`. This key contain a stan
           "image": {
             "arch": "arm",
             "creation_date": "2014-05-22T12:56:56.984011+00:00",
-            "extra_volumes": "[]",
+            "extra_volumes": {},
             "from_image": null,
             "from_server": null,
             "id": "98bf3ac2-a1f5-471d-8c8f-1b706ab57ef0",
@@ -63,7 +63,7 @@ The response is an object that has a key called `images`. This key contain an ar
             {
               "arch": "arm",
               "creation_date": "2014-05-22T12:56:56.984011+00:00",
-              "extra_volumes": "[]",
+              "extra_volumes": {},
               "from_image": null,
               "from_server": null,
               "id": "98bf3ac2-a1f5-471d-8c8f-1b706ab57ef0",
@@ -80,7 +80,7 @@ The response is an object that has a key called `images`. This key contain an ar
             {
               "arch": "arm",
               "creation_date": "2014-05-22T12:57:22.514299+00:00",
-              "extra_volumes": "[]",
+              "extra_volumes": {},
               "from_image": null,
               "from_server": null,
               "id": "1f73d975-35fc-4365-9ead-8dab7e54152f",
@@ -114,7 +114,7 @@ The response is an object that has a key called `image`. This key contain a stan
           "image": {
             "arch": "arm",
             "creation_date": "2014-05-22T12:56:56.984011+00:00",
-            "extra_volumes": "[]",
+            "extra_volumes": {},
             "from_image": null,
             "from_server": null,
             "id": "98bf3ac2-a1f5-471d-8c8f-1b706ab57ef0",
@@ -143,7 +143,7 @@ The response is an object that has a key called `image`. This key contain a stan
             {
                 "arch": "arm", 
                 "creation_date": "2014-05-22T12:57:22.514299+00:00", 
-                "extra_volumes": "[]", 
+                "extra_volumes": {}, 
                 "from_image": null, 
                 "from_server": null, 
                 "id": "1f73d975-35fc-4365-9ead-8dab7e54152f", 
@@ -165,7 +165,7 @@ The response is an object that has a key called `image`. This key contain a stan
           "image": {
             "arch": "arm",
             "creation_date": "2014-05-22T12:56:56.984011+00:00",
-            "extra_volumes": "[]",
+            "extra_volumes": {},
             "from_image": null,
             "from_server": null,
             "id": "98bf3ac2-a1f5-471d-8c8f-1b706ab57ef0",

--- a/contents/server.md
+++ b/contents/server.md
@@ -64,7 +64,7 @@ The response is an object that has a key called `server`. This key contains a st
                     "name": "Ubuntu Xenial",
                     "modification_date": "2018-04-11T06:41:06.414064+00:00",
                     "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-                    "extra_volumes": "[]",
+                    "extra_volumes": {},
                     "arch": "x86_64",
                     "id": "e20532c4-1fa0-4c97-992f-436b8d372c07",
                     "root_volume": {
@@ -178,7 +178,7 @@ The response is an object that has a key called `servers`. This key contains an 
                     "name": "Ubuntu Xenial",
                     "modification_date": "2018-04-11T06:41:06.414064+00:00",
                     "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-                    "extra_volumes": "[]",
+                    "extra_volumes": {},
                     "arch": "x86_64",
                     "id": "e20532c4-1fa0-4c97-992f-436b8d372c07",
                     "root_volume": {
@@ -305,7 +305,7 @@ The response is an object that has a key called `server`. This key contains a st
                 "name": "Ubuntu Xenial",
                 "modification_date": "2018-04-11T06:41:06.414064+00:00",
                 "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-                "extra_volumes": "[]",
+                "extra_volumes": {},
                 "arch": "x86_64",
                 "id": "e20532c4-1fa0-4c97-992f-436b8d372c07",
                 "root_volume": {
@@ -425,7 +425,7 @@ The response is an object that has a key called `server`. This key contains a st
                 "name": "Ubuntu Xenial",
                 "modification_date": "2018-04-11T06:41:06.414064+00:00",
                 "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-                "extra_volumes": "[]",
+                "extra_volumes": {},
                 "arch": "x86_64",
                 "id": "e20532c4-1fa0-4c97-992f-436b8d372c07",
                 "root_volume": {
@@ -538,7 +538,7 @@ The response is an object that has a key called `server`. This key contains a st
                 "name": "Ubuntu Xenial",
                 "modification_date": "2018-04-11T06:41:06.414064+00:00",
                 "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-                "extra_volumes": "[]",
+                "extra_volumes": {},
                 "arch": "x86_64",
                 "id": "e20532c4-1fa0-4c97-992f-436b8d372c07",
                 "root_volume": {


### PR DESCRIPTION
`extra_volumes` used to be string containing [] and was never used.
This was a mistake as it do not really make any sense from a json point of view.

For the backup feature `extra_volumes` will be used, we changed it in order to
contains useful information. It is now a dict.

All your existing images will now display `"extra_volumes": {}`, this is an api
break but as the previous value was useless we hope it will not disturb you too
much.